### PR TITLE
Add a config item to skip the harvesting if the player just left-click the crop

### DIFF
--- a/src/main/java/simplexity/scythe/config/ConfigHandler.java
+++ b/src/main/java/simplexity/scythe/config/ConfigHandler.java
@@ -33,6 +33,7 @@ public class ConfigHandler {
     private final Logger logger = Scythe.getScytheLogger();
     private boolean requireToolReplant;
     private boolean requireToolRightClickHarvest;
+    private boolean leftClickReplant;
     private boolean rightClickHarvest;
     private boolean playSounds;
     private Sound configSound;
@@ -51,6 +52,7 @@ public class ConfigHandler {
         setConfiguredTools();
         checkSound();
         checkParticle();
+        leftClickReplant = config.getBoolean("left-click-replant");
         rightClickHarvest = config.getBoolean("right-click-to-harvest");
         requireToolReplant = config.getBoolean("require-tool-for-replant");
         requireToolRightClickHarvest = config.getBoolean("require-tool-for-right-click-harvest");
@@ -138,6 +140,9 @@ public class ConfigHandler {
         }
     }
 
+    public boolean allowLeftClickReplant() {
+        return leftClickReplant;
+    }
 
     public boolean allowRightClickHarvest() {
         return rightClickHarvest;

--- a/src/main/java/simplexity/scythe/events/HarvestEvent.java
+++ b/src/main/java/simplexity/scythe/events/HarvestEvent.java
@@ -54,6 +54,10 @@ public class HarvestEvent extends Event implements Cancellable {
             setCancelled(true);
             return;
         }
+        if (!isRightClick && !isLeftClickReplantEnabled()) {
+            setCancelled(true);
+            return;
+        }
         if (isRightClick && !isRightClickHarvestEnabled()) {
             setCancelled(true);
             return;
@@ -209,6 +213,14 @@ public class HarvestEvent extends Event implements Cancellable {
      */
     public boolean isCropAllowed() {
         return getConfiguredCropList().contains(getCropMaterial());
+    }
+
+    /**
+     * Returns a boolean value that indicates whether normally breaking the crop triggers the harvest event or not.
+     * <br>The method internally gets the ConfigHandler instance and calls its allowLeftClickReplant() method to retrieve the value.
+     */
+    public boolean isLeftClickReplantEnabled() {
+        return ConfigHandler.getInstance().allowLeftClickReplant();
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 #Scythe
+left-click-replant: true
 right-click-to-harvest: true
 require-tool-for-replant: false
 require-tool-for-right-click-harvest: false


### PR DESCRIPTION
### The problem
- There is no way to remove the seed on the farmland without manually turning the harvesting off.
- There is no way to make harvesting right click only while maintaining the vanilla behavior of the left click.

### Changes
Added a `left-click-replant` config item. You can make the plugin fully disabled, or only enabled for left/right click, or both by using different config combinations.