### PR TITLE
Replace `block.breakNaturally()` with `player.breakBlock()`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.5-R0.1-SNAPSHOT</version>
+            <version>1.21.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/simplexity/scythe/config/ConfigHandler.java
+++ b/src/main/java/simplexity/scythe/config/ConfigHandler.java
@@ -1,9 +1,6 @@
 package simplexity.scythe.config;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -13,6 +10,7 @@ import simplexity.scythe.Scythe;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 /**
@@ -76,7 +74,7 @@ public class ConfigHandler {
     private void checkSound() {
         String sound = Scythe.getInstance().getConfig().getString("sound");
         try {
-            configSound = Sound.valueOf(sound);
+            configSound = Registry.SOUNDS.get(NamespacedKey.fromString(sound.toLowerCase(Locale.ROOT)));
         } catch (IllegalArgumentException | NullPointerException e) {
             Scythe.getScytheLogger().warning(sound + " could not be cast to a sound. Please check your syntax and be sure you are choosing a sound from https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html");
             Scythe.getScytheLogger().warning("Setting sound to BLOCK_CROP_BREAK until a valid sound is provided");

--- a/src/main/java/simplexity/scythe/events/HarvestEvent.java
+++ b/src/main/java/simplexity/scythe/events/HarvestEvent.java
@@ -1,10 +1,7 @@
 package simplexity.scythe.events;
 
 import net.coreprotect.CoreProtectAPI;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
@@ -100,7 +97,7 @@ public class HarvestEvent extends Event implements Cancellable {
             setCancelled(true);
             return;
         }
-        block.breakNaturally(usedItem);
+        player.breakBlock(block);
         if (isCoreProtectEnabled()) {
             coreProtectAPI.logRemoval(player.getName(), getCropLocation(), getCropMaterial(), getCropBlockData());
         }


### PR DESCRIPTION
This PR adds compatibility with [mcMMO](https://github.com/mcMMO-Dev/mcMMO) by using `player.breakBlock()` instead of `block.breakNaturally()` when harvesting crops. mcMMO listens for block break events with an associated Player object to record skill progression.

Ideally, I'd implement the mcMMO API and directly tell it that there's been a harvest event, but it doesn't expose methods for that. There is `herbalismManager.processHerbalismBlockBreakEvent()`, but mcMMO only calls that after a bunch of checks that I'd need to implement manually in Scythe. Long-term it might make sense to submit a PR to mcMMO to extract all of the logic in `BlockListener#onBlockBreak()` to methods that other plugins can use.

I did see the warning in the documentation for `player.breakBlock()`, but I tested and it doesn't seem to cause any event loops or recursion issues inside Scythe.

Note: I had to update the Paper API to 1.21.3 since I wasn't able to download 1.20.5, and there was an API change I needed to address as well.